### PR TITLE
docs: fix permission typo

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -192,7 +192,7 @@ export interface CheckPermissionOptions {
 
 export interface CheckPermissionResult {
   /**
-   * When set to `true`, the ermission is granted.
+   * When set to `true`, the permission is granted.
    */
   granted?: boolean;
 


### PR DESCRIPTION
## Summary
- fix small typo in permission comment

## Testing
- `grep -n "permission is granted" -n src/definitions.ts`

------
https://chatgpt.com/codex/tasks/task_e_6841fd7275f8832b8c447506f5917522