### PR TITLE
Add photo capture method

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
+++ b/android/src/main/java/com/getcapacitor/community/barcodescanner/BarcodeScanner.java
@@ -583,4 +583,23 @@ public class BarcodeScanner extends Plugin implements BarcodeCallback {
 
         call.resolve(result);
     }
+
+    @PluginMethod
+    public void getPhoto(PluginCall call) {
+        JSObject result = new JSObject();
+
+        if (mBarcodeView != null) {
+            Bitmap bitmap = mBarcodeView.getBitmap();
+            if (bitmap != null) {
+                ByteArrayOutputStream stream = new ByteArrayOutputStream();
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+                String img = "data:image/png;base64," + Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP);
+                result.put("image", img);
+                call.resolve(result);
+                return;
+            }
+        }
+
+        call.reject("Unable to capture image");
+    }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -14,6 +14,7 @@ export interface BarcodeScannerPlugin {
   disableTorch(): Promise<void>;
   toggleTorch(): Promise<void>;
   getTorchState(): Promise<TorchStateResult>;
+  getPhoto(): Promise<PhotoResult>;
 }
 
 const _SupportedFormat = {
@@ -251,4 +252,11 @@ export interface TorchStateResult {
    * Whether or not the torch is currently enabled.
    */
   isEnabled: boolean;
+}
+
+export interface PhotoResult {
+  /**
+   * Base64 encoded image of the current camera frame.
+   */
+  image?: string;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -10,6 +10,7 @@ import {
   CheckPermissionResult,
   StopScanOptions,
   TorchStateResult,
+  PhotoResult,
   CameraDirection,
   IScanResultWithContent,
 } from './definitions';
@@ -184,6 +185,20 @@ export class BarcodeScannerWeb extends WebPlugin implements BarcodeScannerPlugin
 
   async getTorchState(): Promise<TorchStateResult> {
     return { isEnabled: this._torchState };
+  }
+
+  async getPhoto(): Promise<PhotoResult> {
+    const video = await this._getVideoElement();
+    if (video) {
+      const canvas = document.createElement('canvas');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d');
+      ctx?.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const image = canvas.toDataURL('image/png');
+      return { image };
+    }
+    throw this.unavailable('Missing video element');
   }
 
   private async _getVideoElement() {


### PR DESCRIPTION
## Summary
- expose `getPhoto` API to fetch a frame image
- implement new call for Android
- implement new call for iOS
- support new call on the web plugin
- run camera session on a background queue and use `AVCapturePhotoOutput` for reliable capture on iOS

## Testing
- `npm run build`
- `npm run verify:web`
- `npm run verify:android` *(fails: Unsupported class file major version 65)*
- `npm run verify:ios` *(fails: pod: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482d1f0798832b8d91bacce23186f6